### PR TITLE
error adjusted stop loss

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ URL = 'https://github.mmm.com/nga-27/intellistop'
 EMAIL = 'namell91@gmail.com'
 AUTHOR = 'Nick Amell'
 REQUIRES_PYTHON = '>=3.8.0'
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 # What packages are required for this module to be executed?
 REQUIRES = [


### PR DESCRIPTION
In the end, stop losses are still a little bit arbitrary, so to fully trigger off a _single closing amount_ that's below it seems a little aggressive. There can be thresholds and safeguards around it for sure. One such thing is to prevent a stop out when the equity is actually bouncing around at the bottom, hopping above and blow the line, only to majorly rebound for the positive. If it rebounds, you've probably already stopped out by accident and actually missed a major opportunity to buy.

This PR implements an error factor, effectively `error_factor = VF/50.0 * 2%`. So for a VF that's conservative, say 5%, only a 0.2% error_factor is provided. For something very volatile, a full 2% error_factor will be provided.

Essentially, if an equity drops in price below the stop loss, it has a one-period trading "grace period", where it needs to either pop above the stop loss or within the error zone on the following trading period. The error zone threshold, then, is defined by `error_zone_threshold = stop_loss * (1 - error_factor)`. If the price rebounds below the stop loss but above the error_zone_threshold, it can has an additional grace period of one trading period. If, on the next grace period, it drops below the error_zone_threshold, it is officially stopped out. 